### PR TITLE
Prevent stationary commands while marching

### DIFF
--- a/app/marching/constants.ts
+++ b/app/marching/constants.ts
@@ -51,6 +51,13 @@ export const VALID_PREP_EXEC_PAIRS = new Set(
     .map(([prep, exec]) => `${prep}|${exec}`)
 );
 
+export const STATIONARY_PREP_EXEC_PAIRS = new Set([
+  'LEFT|FACE',
+  'RIGHT|FACE',
+  'ABOUT|FACE',
+  'FLIGHT|FALL-IN',
+]);
+
 export const SCORABLE_COMMANDS: Array<[AtomicCommand, AtomicCommand]> = [
   ['FORWARD', 'MARCH'],
   ['LEFT', 'FACE'],


### PR DESCRIPTION
## Summary
- add `STATIONARY_PREP_EXEC_PAIRS` constants for invalid marching pairs
- block stationary commands when the flight is marching

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842d44e2674832cbaf05607a4381135